### PR TITLE
v8 libplatform: enable z/OS support

### DIFF
--- a/deps/v8/include/libplatform/v8-tracing.h
+++ b/deps/v8/include/libplatform/v8-tracing.h
@@ -59,11 +59,19 @@ class V8_PLATFORM_EXPORT TraceObject {
       const char** arg_names, const uint8_t* arg_types,
       const uint64_t* arg_values,
       std::unique_ptr<v8::ConvertableToTraceFormat>* arg_convertables,
+#if defined(V8_OS_ZOS)
+      unsigned int flags, int pid, pthread_t tid, int64_t ts, int64_t tts,
+#else
       unsigned int flags, int pid, int tid, int64_t ts, int64_t tts,
+#endif
       uint64_t duration, uint64_t cpu_duration);
 
   int pid() const { return pid_; }
+#if defined(V8_OS_ZOS)
+  pthread_t tid() const { return tid_; }
+#else
   int tid() const { return tid_; }
+#endif
   char phase() const { return phase_; }
   const uint8_t* category_enabled_flag() const {
     return category_enabled_flag_;
@@ -87,7 +95,11 @@ class V8_PLATFORM_EXPORT TraceObject {
 
  private:
   int pid_;
+#if defined(V8_OS_ZOS)
+  pthread_t tid_;
+#else
   int tid_;
+#endif
   char phase_;
   const char* name_;
   const char* scope_;

--- a/deps/v8/include/v8config.h
+++ b/deps/v8/include/v8config.h
@@ -120,6 +120,9 @@
 # define V8_OS_QNX 1
 #elif defined(_WIN32)
 # define V8_OS_WIN 1
+#elif defined(__MVS__)
+# define V8_OS_POSIX 1
+# define V8_OS_ZOS 1
 #endif
 
 // -----------------------------------------------------------------------------

--- a/deps/v8/src/base/debug/stack_trace_posix.cc
+++ b/deps/v8/src/base/debug/stack_trace_posix.cc
@@ -14,7 +14,9 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
+#ifndef V8_OS_ZOS
 #include <sys/param.h>
+#endif
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>

--- a/deps/v8/src/base/platform/platform-posix.cc
+++ b/deps/v8/src/base/platform/platform-posix.cc
@@ -159,7 +159,7 @@ void* Allocate(void* hint, size_t size, OS::MemoryPermission access) {
   return result;
 }
 
-#endif  // !V8_OS_FUCHSIA
+#endif  // !V8_OS_FUCHSIA && !V8_OS_ZOS
 
 }  // namespace
 
@@ -205,7 +205,7 @@ bool OS::ArmUsingHardFloat() {
 }
 
 #endif  // def __arm__
-#endif  // !V8_OS_FUCHSIA && !V8_OS_ZOS 
+#endif  // V8_OS_LINUX || V8_OS_FREEBSD
 
 void OS::Initialize(bool hard_abort, const char* const gc_fake_mmap) {
   g_hard_abort = hard_abort;
@@ -395,6 +395,8 @@ bool OS::SetPermissions(void* address, size_t size, MemoryPermission access) {
   DCHECK_EQ(0, size % CommitPageSize());
 
 #if defined(V8_OS_ZOS)
+  //TODO - should implement, see:
+  //https://www.ibm.com/support/knowledgecenter/SSLTBW_2.2.0/com.ibm.zos.v2r2.bpxb100/mpr.htm
   return true;	
 #else
   int prot = GetProtectionFromMemoryPermission(access);

--- a/deps/v8/src/base/platform/platform-posix.cc
+++ b/deps/v8/src/base/platform/platform-posix.cc
@@ -19,10 +19,13 @@
 
 #include <sys/mman.h>
 #include <sys/stat.h>
+#if defined(V8_OS_ZOS)
+#include <signal.h>
+#endif
 #include <sys/time.h>
 #include <sys/types.h>
 #if defined(__APPLE__) || defined(__DragonFly__) || defined(__FreeBSD__) || \
-    defined(__NetBSD__) || defined(__OpenBSD__)
+    defined(__NetBSD__) || defined(__OpenBSD__) && !defined(V8_OS_ZOS)
 #include <sys/sysctl.h>  // NOLINT, for sysctl
 #endif
 
@@ -61,7 +64,7 @@
 #include <sys/resource.h>
 #endif
 
-#if !defined(_AIX) && !defined(V8_OS_FUCHSIA)
+#if !defined(_AIX) && !defined(V8_OS_FUCHSIA) && !defined(V8_OS_ZOS)
 #include <sys/syscall.h>
 #endif
 
@@ -86,8 +89,18 @@ namespace base {
 
 namespace {
 
+#if defined(V8_OS_ZOS)
+inline bool operator==(const pthread_t &_a, const pthread_t &_b) {
+  return _a.__ == _b.__;
+}
+#endif
+
 // 0 is never a valid thread id.
+#if V8_OS_ZOS
+const pthread_t kNoThread = {0};
+#else
 const pthread_t kNoThread = static_cast<pthread_t>(0);
+#endif
 
 bool g_hard_abort = false;
 
@@ -97,7 +110,7 @@ DEFINE_LAZY_LEAKY_OBJECT_GETTER(RandomNumberGenerator,
                                 GetPlatformRandomNumberGenerator)
 static LazyMutex rng_mutex = LAZY_MUTEX_INITIALIZER;
 
-#if !V8_OS_FUCHSIA
+#if !V8_OS_FUCHSIA && !V8_OS_ZOS 
 #if V8_OS_MACOSX
 // kMmapFd is used to pass vm_alloc flags to tag the region with the user
 // defined tag 255 This helps identify V8-allocated regions in memory analysis
@@ -192,7 +205,7 @@ bool OS::ArmUsingHardFloat() {
 }
 
 #endif  // def __arm__
-#endif
+#endif  // !V8_OS_FUCHSIA && !V8_OS_ZOS 
 
 void OS::Initialize(bool hard_abort, const char* const gc_fake_mmap) {
   g_hard_abort = hard_abort;
@@ -239,6 +252,9 @@ void OS::SetRandomMmapSeed(int64_t seed) {
 
 // static
 void* OS::GetRandomMmapAddr() {
+#if defined(V8_OS_ZOS)
+  return nullptr;
+#endif
   uintptr_t raw_addr;
   {
     MutexGuard guard(rng_mutex.Pointer());
@@ -322,6 +338,7 @@ void* OS::GetRandomMmapAddr() {
 
 // TODO(bbudge) Move Cygwin and Fuchsia stuff into platform-specific files.
 #if !V8_OS_CYGWIN && !V8_OS_FUCHSIA
+#if !V8_OS_ZOS
 // static
 void* OS::Allocate(void* hint, size_t size, size_t alignment,
                    MemoryPermission access) {
@@ -370,12 +387,16 @@ bool OS::Release(void* address, size_t size) {
   DCHECK_EQ(0, size % CommitPageSize());
   return munmap(address, size) == 0;
 }
+#endif // !V8_OS_ZOS
 
 // static
 bool OS::SetPermissions(void* address, size_t size, MemoryPermission access) {
   DCHECK_EQ(0, reinterpret_cast<uintptr_t>(address) % CommitPageSize());
   DCHECK_EQ(0, size % CommitPageSize());
 
+#if defined(V8_OS_ZOS)
+  return true;	
+#else
   int prot = GetProtectionFromMemoryPermission(access);
   int ret = mprotect(address, size, prot);
   if (ret == 0 && access == OS::MemoryPermission::kNoAccess) {
@@ -395,11 +416,15 @@ bool OS::SetPermissions(void* address, size_t size, MemoryPermission access) {
 #endif
 
   return ret == 0;
+#endif
 }
 
 bool OS::DiscardSystemPages(void* address, size_t size) {
   DCHECK_EQ(0, reinterpret_cast<uintptr_t>(address) % CommitPageSize());
   DCHECK_EQ(0, size % CommitPageSize());
+#if V8_OS_ZOS
+  return true;
+#else
 #if defined(OS_MACOSX)
   // On OSX, MADV_FREE_REUSABLE has comparable behavior to MADV_FREE, but also
   // marks the pages with the reusable bit, which allows both Activity Monitor
@@ -423,6 +448,7 @@ bool OS::DiscardSystemPages(void* address, size_t size) {
 #endif
   }
   return ret == 0;
+#endif
 }
 
 // static
@@ -434,7 +460,7 @@ bool OS::HasLazyCommits() {
   return false;
 #endif
 }
-#endif  // !V8_OS_CYGWIN && !V8_OS_FUCHSIA
+#endif  // !V8_OS_CYGWIN && !V8_OS_FUCHSIA && !V8_OS_ZOS
 
 const char* OS::GetGCFakeMMapFile() {
   return g_gc_fake_mmap;
@@ -450,6 +476,7 @@ void OS::Abort() {
   if (g_hard_abort) {
     V8_IMMEDIATE_CRASH();
   }
+
   // Redirect to std abort to signal abnormal program termination.
   abort();
 }
@@ -471,14 +498,19 @@ void OS::DebugBreak() {
 #elif V8_HOST_ARCH_X64
   asm("int $3");
 #elif V8_HOST_ARCH_S390
+#if V8_OS_ZOS
+  // TODO
+#else
   // Software breakpoint instruction is 0x0001
   asm volatile(".word 0x0001");
+#endif
 #else
 #error Unsupported host architecture.
 #endif
 }
 
 
+#ifndef V8_OS_ZOS
 class PosixMemoryMappedFile final : public OS::MemoryMappedFile {
  public:
   PosixMemoryMappedFile(FILE* file, void* memory, size_t size)
@@ -545,13 +577,18 @@ PosixMemoryMappedFile::~PosixMemoryMappedFile() {
   fclose(file_);
 }
 
+#endif //V8_OS_ZOS
 
 int OS::GetCurrentProcessId() {
   return static_cast<int>(getpid());
 }
 
 
+#if defined(V8_OS_ZOS)
+pthread_t OS::GetCurrentThreadId() {
+#else
 int OS::GetCurrentThreadId() {
+#endif
 #if V8_OS_MACOSX || (V8_OS_ANDROID && defined(__APPLE__))
   return static_cast<int>(pthread_mach_thread_np(pthread_self()));
 #elif V8_OS_LINUX
@@ -564,6 +601,8 @@ int OS::GetCurrentThreadId() {
   return static_cast<int>(zx_thread_self());
 #elif V8_OS_SOLARIS
   return static_cast<int>(pthread_self());
+#elif V8_OS_ZOS
+  return pthread_self();
 #else
   return static_cast<int>(reinterpret_cast<intptr_t>(pthread_self()));
 #endif
@@ -795,7 +834,9 @@ static void* ThreadEntry(void* arg) {
   // one).
   { MutexGuard lock_guard(&thread->data()->thread_creation_mutex_); }
   SetThreadName(thread->name());
+#ifndef V8_OS_ZOS
   DCHECK_NE(thread->data()->thread_, kNoThread);
+#endif
   thread->NotifyStartedAndRun();
   return nullptr;
 }
@@ -820,6 +861,14 @@ bool Thread::Start() {
 #elif V8_OS_AIX
     // Default on AIX is 96kB -- bump up to 2MB
     stack_size = 2 * 1024 * 1024;
+#elif V8_OS_ZOS
+    // On z/OS if the _CEE_RUNOPTS STACK64/THREADSTACK64 initial stack size is
+    // less than 4 MB (default for FLAG_stack_size), bump it to 4MB
+    const size_t default_stack_size = 4 * 1024 * 1024;
+    result = pthread_attr_getstacksize(&attr, &stack_size);
+    DCHECK_EQ(0, result);
+    if (stack_size < default_stack_size)
+        stack_size = default_stack_size;
 #endif
   }
   if (stack_size > 0) {

--- a/deps/v8/src/base/platform/platform.h
+++ b/deps/v8/src/base/platform/platform.h
@@ -246,7 +246,11 @@ class V8_BASE_EXPORT OS {
 
   static int GetCurrentProcessId();
 
+#if defined(V8_OS_ZOS)
+  static pthread_t GetCurrentThreadId();
+#else
   static int GetCurrentThreadId();
+#endif
 
   static void AdjustSchedulingParams();
 
@@ -312,7 +316,11 @@ inline void EnsureConsoleOutput() {
 class V8_BASE_EXPORT Thread {
  public:
   // Opaque data type for thread-local storage keys.
+#if defined(V8_OS_ZOS)
+  using LocalStorageKey = pthread_key_t;
+#else
   using LocalStorageKey = int32_t;
+#endif
 
   class Options {
    public:

--- a/deps/v8/src/base/platform/semaphore.h
+++ b/deps/v8/src/base/platform/semaphore.h
@@ -14,7 +14,11 @@
 #if V8_OS_MACOSX
 #include <dispatch/dispatch.h>  // NOLINT
 #elif V8_OS_POSIX
+#if V8_OS_ZOS
+#include "src/s390/semaphore-zos.h"
+#else
 #include <semaphore.h>  // NOLINT
+#endif
 #endif
 
 namespace v8 {

--- a/deps/v8/src/base/platform/time.cc
+++ b/deps/v8/src/base/platform/time.cc
@@ -14,6 +14,9 @@
 #include <mach/mach_time.h>
 #include <pthread.h>
 #endif
+#if V8_OS_ZOS
+#include "zos.h"
+#endif
 
 #include <cstring>
 #include <ostream>
@@ -64,7 +67,7 @@ int64_t ComputeThreadTicks() {
 // _POSIX_MONOTONIC_CLOCK to -1.
 V8_INLINE int64_t ClockNow(clockid_t clk_id) {
 #if (defined(_POSIX_MONOTONIC_CLOCK) && _POSIX_MONOTONIC_CLOCK >= 0) || \
-  defined(V8_OS_BSD) || defined(V8_OS_ANDROID)
+  defined(V8_OS_BSD) || defined(V8_OS_ANDROID) || defined(V8_OS_ZOS)
 // On AIX clock_gettime for CLOCK_THREAD_CPUTIME_ID outputs time with
 // resolution of 10ms. thread_cputime API provides the time in ns
 #if defined(V8_OS_AIX)
@@ -752,8 +755,9 @@ bool TimeTicks::IsHighResolution() {
 
 
 bool ThreadTicks::IsSupported() {
-#if (defined(_POSIX_THREAD_CPUTIME) && (_POSIX_THREAD_CPUTIME >= 0)) || \
-    defined(V8_OS_MACOSX) || defined(V8_OS_ANDROID) || defined(V8_OS_SOLARIS)
+#if defined(_POSIX_THREAD_CPUTIME) && (_POSIX_THREAD_CPUTIME >= 0) || \
+    defined(V8_OS_MACOSX) || defined(V8_OS_ANDROID) || defined(V8_OS_SOLARIS) || \
+    defined(V8_OS_ZOS)
   return true;
 #elif defined(V8_OS_WIN)
   return IsSupportedWin();
@@ -767,7 +771,7 @@ ThreadTicks ThreadTicks::Now() {
 #if V8_OS_MACOSX
   return ThreadTicks(ComputeThreadTicks());
 #elif(defined(_POSIX_THREAD_CPUTIME) && (_POSIX_THREAD_CPUTIME >= 0)) || \
-  defined(V8_OS_ANDROID)
+  defined(V8_OS_ANDROID) || defined(V8_OS_ZOS)
   return ThreadTicks(ClockNow(CLOCK_THREAD_CPUTIME_ID));
 #elif V8_OS_SOLARIS
   return ThreadTicks(gethrvtime() / Time::kNanosecondsPerMicrosecond);

--- a/deps/v8/src/base/sys-info.cc
+++ b/deps/v8/src/base/sys-info.cc
@@ -25,6 +25,9 @@
 #if V8_OS_WIN
 #include "src/base/win32-headers.h"
 #endif
+#if V8_OS_ZOS
+#include "src/base/sys-info-zos.h"
+#endif
 
 namespace v8 {
 namespace base {
@@ -39,6 +42,11 @@ int SysInfo::NumberOfProcessors() {
     return 1;
   }
   return ncpu;
+#elif V8_OS_ZOS
+  ZOSCVT* __ptr32 cvt = ((ZOSPSA*)0)->cvt;
+  ZOSRMCT* __ptr32 rmct = cvt->rmct;
+  ZOSCCT* __ptr32 cct = rmct->cct;
+  return static_cast<int>(cct->cpuCount);
 #elif V8_OS_POSIX
   long result = sysconf(_SC_NPROCESSORS_ONLN);  // NOLINT(runtime/int)
   if (result == -1) {
@@ -90,6 +98,12 @@ int64_t SysInfo::AmountOfPhysicalMemory() {
 #elif V8_OS_AIX
   int64_t result = sysconf(_SC_AIX_REALMEM);
   return static_cast<int64_t>(result) * 1024L;
+#elif V8_OS_ZOS
+  ZOSCVT * __ptr32 cvt = ((ZOSPSA*)0)->cvt;
+  ZOSRCE * __ptr32 rce = cvt->rce;
+  intptr_t pages = rce->pool;
+  intptr_t page_size = sysconf(_SC_PAGESIZE);
+  return static_cast<uint64_t>(pages) * page_size;
 #elif V8_OS_POSIX
   long pages = sysconf(_SC_PHYS_PAGES);    // NOLINT(runtime/int)
   long page_size = sysconf(_SC_PAGESIZE);  // NOLINT(runtime/int)

--- a/deps/v8/src/libplatform/tracing/trace-object.cc
+++ b/deps/v8/src/libplatform/tracing/trace-object.cc
@@ -113,7 +113,11 @@ void TraceObject::InitializeForTesting(
     const char** arg_names, const uint8_t* arg_types,
     const uint64_t* arg_values,
     std::unique_ptr<v8::ConvertableToTraceFormat>* arg_convertables,
+#if defined(V8_OS_ZOS)
+    unsigned int flags, int pid, pthread_t tid, int64_t ts, int64_t tts,
+#else
     unsigned int flags, int pid, int tid, int64_t ts, int64_t tts,
+#endif
     uint64_t duration, uint64_t cpu_duration) {
   pid_ = pid;
   tid_ = tid;

--- a/deps/v8/src/libplatform/tracing/trace-writer.cc
+++ b/deps/v8/src/libplatform/tracing/trace-writer.cc
@@ -131,8 +131,14 @@ JSONTraceWriter::~JSONTraceWriter() { stream_ << "]}"; }
 void JSONTraceWriter::AppendTraceEvent(TraceObject* trace_event) {
   if (append_comma_) stream_ << ",";
   append_comma_ = true;
+#if defined(V8_OS_ZOS)
+  pthread_t tid = trace_event->tid();
+  stream_ << "{\"pid\":" << trace_event->pid()
+          << ",\"tid\":" << int(tid.__ & 0x7fffffff)
+#else
   stream_ << "{\"pid\":" << trace_event->pid()
           << ",\"tid\":" << trace_event->tid()
+#endif
           << ",\"ts\":" << trace_event->ts()
           << ",\"tts\":" << trace_event->tts() << ",\"ph\":\""
           << trace_event->phase() << "\",\"cat\":\""

--- a/deps/v8/src/torque/contextual.h
+++ b/deps/v8/src/torque/contextual.h
@@ -83,6 +83,7 @@ class ContextualVariable {
       : v8::internal::torque::ContextualVariable<VarName, __VA_ARGS__> {}
 
 #if defined(V8_OS_ZOS)
+//FIXME: revert when Clang compiler is available (supports thread_local)
 #define DEFINE_CONTEXTUAL_VARIABLE(VarName)                             \
   template <>                                                           \
   V8_EXPORT_PRIVATE VarName::Scope*& ContextualVariableTop<VarName>() { \

--- a/deps/v8/src/torque/contextual.h
+++ b/deps/v8/src/torque/contextual.h
@@ -82,12 +82,21 @@ class ContextualVariable {
   struct VarName                                  \
       : v8::internal::torque::ContextualVariable<VarName, __VA_ARGS__> {}
 
+#if defined(V8_OS_ZOS)
+#define DEFINE_CONTEXTUAL_VARIABLE(VarName)                             \
+  template <>                                                           \
+  V8_EXPORT_PRIVATE VarName::Scope*& ContextualVariableTop<VarName>() { \
+    static VarName::Scope* top = nullptr;                               \
+    return top;                                                         \
+  }
+#else
 #define DEFINE_CONTEXTUAL_VARIABLE(VarName)                             \
   template <>                                                           \
   V8_EXPORT_PRIVATE VarName::Scope*& ContextualVariableTop<VarName>() { \
     static thread_local VarName::Scope* top = nullptr;                  \
     return top;                                                         \
   }
+#endif
 
 // By inheriting from {ContextualClass} a class can become a contextual variable
 // of itself, which is very similar to a singleton.


### PR DESCRIPTION
Enable building of libv8_libplatform.a for z/OS:
- set V8_OS_POSIX and V8_OS_ZOS macros for z/OS
- use pthread_t, pthread_key_t and sem_t types on z/OS
- implement cpu count and memory size for z/OS
- support trace event display of pthread_t tid on z/OS
- implement non-int pthread_t == operator and init
- enable d8 to read EBCDIC in tagged/untagged source
- temporarily disable unsupported DebugBreak()
- set initial stack size
- move class PosixMemoryMappedFile to platform-zos.cc
- use z/OS implementation of clock_gettime()