### PR TITLE
tools: Enable tests for z/OS

### DIFF
--- a/tools/test.py
+++ b/tools/test.py
@@ -633,7 +633,7 @@ def KillProcessWithID(pid, signal_to_send=signal.SIGTERM):
       # Try again with killharder z/OS utility
       from distutils.spawn import find_executable
       if find_executable("killharder") is not None:
-	    os.system("killharder " + str(pid));
+        os.system("killharder " + str(pid));
   else:
     os.kill(pid, signal_to_send)
 

--- a/tools/test.py
+++ b/tools/test.py
@@ -297,7 +297,8 @@ class TapProgressIndicator(SimpleProgressIndicator):
     logger.info('  stack: |-')
 
     for l in self.traceback.splitlines():
-      logger.info('    ' + l)
+      # Leading whitespaces can cause Jenkins TAP parser error.
+      logger.info('    ' + l.lstrip())
 
   def Starting(self):
     logger.info('TAP version 13')
@@ -620,6 +621,19 @@ class TestOutput(object):
 def KillProcessWithID(pid, signal_to_send=signal.SIGTERM):
   if utils.IsWindows():
     os.popen('taskkill /T /F /PID %d' % pid)
+  elif utils.IsZos():
+    os.kill(pid, signal_to_send)
+    # On z/OS, the process may not be killed with SIGTERM
+    try:
+      # Check if process still exists
+      os.kill(pid, 0)
+    except OSError:
+      pass # process killed
+    else:
+      # Try again with killharder z/OS utility
+      from distutils.spawn import find_executable
+      if find_executable("killharder") is not None:
+	    os.system("killharder " + str(pid));
   else:
     os.kill(pid, signal_to_send)
 

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -71,6 +71,8 @@ def GuessOS():
     return 'aix'
   elif id == 'OS400':
     return 'ibmi'
+  elif id == 'OS/390':
+    return 'zos'
   else:
     return None
 
@@ -106,3 +108,6 @@ def GuessArchitecture():
 
 def IsWindows():
   return GuessOS() == 'win32'
+
+def IsZos():
+  return GuessOS() == 'zos'


### PR DESCRIPTION
* Add z/OS support for running tests (in tests.py and utils.py)

Modified the logic from node-v12 to check if the process is still running rather than sleeping for 5 seconds and checking if `killharder` exists