### PR TITLE
tools,node,build: Initial commit for versioned node shared libraries and install for z/OS

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1215,7 +1215,7 @@ def configure_node(o):
   elif sys.platform.startswith('aix'):
     shlib_suffix = '%s.a'
   elif sys.platform.startswith('zos'):
-    shlib_suffix = 'x'
+    shlib_suffix = '%s.x'
   else:
     shlib_suffix = 'so.%s'
   if '%s' in shlib_suffix:

--- a/deps/npm/node_modules/node-gyp/lib/configure.js
+++ b/deps/npm/node_modules/node-gyp/lib/configure.js
@@ -261,6 +261,8 @@ function configure (gyp, argv, callback) {
         })
       } else {
         candidates = [
+          'out/Release/lib.target/libnode',
+          'out/Debug/lib.target/libnode',
           'out/Release/obj.target/libnode',
           'out/Debug/obj.target/libnode',
           'lib/libnode'

--- a/src/node_main.cc
+++ b/src/node_main.cc
@@ -93,10 +93,13 @@ extern char** environ;
 #ifdef __MVS__
 #include <zos.h>
 // Initialize environment and zoslib
-__init_zoslib __nodezoslib("__IPC_CLEANUP", "__NODERUNDEBUG", "__NODERUNTIMELIMIT"
+__init_zoslib __nodezoslib("__IPC_CLEANUP", 
+              "__NODERUNDEBUG", 
+              "__NODERUNTIMELIMIT"
               "__NODEFORKMAX");
 
-__setlibpath __nodelibpath; // Initialize LIBPATH
+// Initialize LIBPATH
+__setlibpath __nodelibpath;
 #endif
 
 namespace node {

--- a/src/node_main.cc
+++ b/src/node_main.cc
@@ -90,6 +90,15 @@ extern char** environ;
 #include <signal.h>
 #endif
 
+#ifdef __MVS__
+#include <zos.h>
+// Initialize environment and zoslib
+__init_zoslib __nodezoslib("__IPC_CLEANUP", "__NODERUNDEBUG", "__NODERUNTIMELIMIT"
+              "__NODEFORKMAX");
+
+__setlibpath __nodelibpath; // Initialize LIBPATH
+#endif
+
 namespace node {
 namespace per_process {
 extern bool linux_at_secure;
@@ -109,6 +118,12 @@ int main(int argc, char* argv[]) {
     act.sa_handler = SIG_IGN;
     sigaction(SIGPIPE, &act, nullptr);
   }
+#endif
+
+#if defined(__MVS__)
+    __set_autocvt_on_untagged_fd_stream(STDIN_FILENO, 1047, 1);
+    __set_autocvt_on_untagged_fd_stream(STDOUT_FILENO, 1047, 1);
+    __set_autocvt_on_untagged_fd_stream(STDERR_FILENO, 1047, 1);
 #endif
 
 #if defined(__linux__)

--- a/tools/gyp/pylib/gyp/generator/make.py
+++ b/tools/gyp/pylib/gyp/generator/make.py
@@ -950,16 +950,16 @@ $(obj).$(TOOLSET)/$(TARGET)/%%.o: $(obj)/%%%s FORCE_DO_CMD
       # TODO(piman): when everything is cross-compile safe, remove lib.target
       if self.flavor == 'zos':
         self.WriteLn('cmd_%s = LIBPATH=$(builddir)/lib.host:'
-                   '$(builddir)/lib.target:$(builddir)/obj.target:$$LIBPATH; '
-                   'export LIBPATH; '
-                   '%s%s'
-                   % (name, cd_action, command))
+                     '$(builddir)/lib.target:$$LIBPATH; '
+                     'export LIBPATH; '
+                     '%s%s'
+                     % (name, cd_action, command))
       else:
         self.WriteLn('cmd_%s = LD_LIBRARY_PATH=$(builddir)/lib.host:'
-                   '$(builddir)/lib.target:$$LD_LIBRARY_PATH; '
-                   'export LD_LIBRARY_PATH; '
-                   '%s%s'
-                   % (name, cd_action, command))
+                     '$(builddir)/lib.target:$$LD_LIBRARY_PATH; '
+                     'export LD_LIBRARY_PATH; '
+                     '%s%s'
+                     % (name, cd_action, command))
       self.WriteLn()
       outputs = [self.Absolutify(o) for o in outputs]
       # The makefile rules are all relative to the top dir, but the gyp actions
@@ -1706,7 +1706,7 @@ $(obj).$(TOOLSET)/$(TARGET)/%%.o: $(obj)/%%%s FORCE_DO_CMD
       install_path = self._InstallableTargetInstallPath()
       installable_deps = []
       if (self.flavor != 'zos'):
-        installable_deps.append(self.outputr)
+        installable_deps.append(self.output)
       if (self.flavor == 'mac' and not 'product_dir' in spec and
           self.toolset == 'target'):
         # On mac, products are created in install_path immediately.

--- a/tools/gyp/pylib/gyp/generator/make.py
+++ b/tools/gyp/pylib/gyp/generator/make.py
@@ -96,6 +96,8 @@ def CalculateVariables(default_variables, params):
     default_variables.setdefault('OS', operating_system)
     if flavor == 'aix':
       default_variables.setdefault('SHARED_LIB_SUFFIX', '.a')
+    elif flavor == 'zos':
+      default_variables.setdefault('SHARED_LIB_SUFFIX', '.x')
     else:
       default_variables.setdefault('SHARED_LIB_SUFFIX', '.so')
     default_variables.setdefault('SHARED_LIB_DIR','$(builddir)/lib.$(TOOLSET)')
@@ -234,7 +236,7 @@ cmd_solink_module = $(LINK.$(TOOLSET)) -shared $(GYP_LDFLAGS) $(LDFLAGS.$(TOOLSE
 """
 
 
-LINK_COMMANDS_OS390 = """\
+LINK_COMMANDS_ZOS = """\
 quiet_cmd_alink = AR($(TOOLSET)) $@
 cmd_alink = rm -f $@ && $(AR.$(TOOLSET)) crs $@ $(filter %.o,$^)
 
@@ -245,11 +247,10 @@ quiet_cmd_link = LINK($(TOOLSET)) $@
 cmd_link = $(LINK.$(TOOLSET)) $(GYP_LDFLAGS) $(LDFLAGS.$(TOOLSET)) -o $@ $(LD_INPUTS) $(LIBS)
 
 quiet_cmd_solink = SOLINK($(TOOLSET)) $@
-cmd_solink = $(LINK.$(TOOLSET)) $(GYP_LDFLAGS) $(LDFLAGS.$(TOOLSET)) -o $@ $(LD_INPUTS) $(LIBS) -Wl,DLL
+cmd_solink = $(LINK.$(TOOLSET)) $(GYP_LDFLAGS) $(LDFLAGS.$(TOOLSET)) -Wl,DLL -o $(patsubst %.x,%.so,$@) $(LD_INPUTS) $(LIBS) && if [ -f $(notdir $@) ]; then /bin/cp $(notdir $@) $@; else true; fi
 
 quiet_cmd_solink_module = SOLINK_MODULE($(TOOLSET)) $@
-cmd_solink_module = $(LINK.$(TOOLSET)) $(GYP_LDFLAGS) $(LDFLAGS.$(TOOLSET)) -o $@ $(filter-out FORCE_DO_CMD, $^) $(LIBS) -Wl,DLL
-
+cmd_solink_module = $(LINK.$(TOOLSET)) $(GYP_LDFLAGS) $(LDFLAGS.$(TOOLSET)) -o $@ $(filter-out FORCE_DO_CMD, $^) $(LIBS)
 """
 
 
@@ -392,6 +393,9 @@ cmd_touch = touch $@
 quiet_cmd_copy = COPY $@
 # send stderr to /dev/null to ignore messages when linking directories.
 cmd_copy = ln -f "$<" "$@" 2>/dev/null || (rm -rf "$@" && cp %(copy_archive_args)s "$<" "$@")
+
+quiet_cmd_symlink = SYMLINK $@
+cmd_symlink = ln -sf "$<" "$@"
 
 %(link_commands)s
 """
@@ -944,7 +948,14 @@ $(obj).$(TOOLSET)/$(TARGET)/%%.o: $(obj)/%%%s FORCE_DO_CMD
       # libraries, but until everything is made cross-compile safe, also use
       # target libraries.
       # TODO(piman): when everything is cross-compile safe, remove lib.target
-      self.WriteLn('cmd_%s = LD_LIBRARY_PATH=$(builddir)/lib.host:'
+      if self.flavor == 'zos':
+        self.WriteLn('cmd_%s = LIBPATH=$(builddir)/lib.host:'
+                   '$(builddir)/lib.target:$(builddir)/obj.target:$$LIBPATH; '
+                   'export LIBPATH; '
+                   '%s%s'
+                   % (name, cd_action, command))
+      else:
+        self.WriteLn('cmd_%s = LD_LIBRARY_PATH=$(builddir)/lib.host:'
                    '$(builddir)/lib.target:$$LD_LIBRARY_PATH; '
                    'export LD_LIBRARY_PATH; '
                    '%s%s'
@@ -1085,17 +1096,30 @@ $(obj).$(TOOLSET)/$(TARGET)/%%.o: $(obj)/%%%s FORCE_DO_CMD
         # libraries, but until everything is made cross-compile safe, also use
         # target libraries.
         # TODO(piman): when everything is cross-compile safe, remove lib.target
-        self.WriteLn(
-            "cmd_%(name)s_%(count)d = LD_LIBRARY_PATH="
+        if self.flavor == 'zos':
+          self.WriteLn(
+              "cmd_%(name)s_%(count)d = LIBPATH="
+              "$(builddir)/lib.host:$(builddir)/lib.target:$$LIBPATH; "
+              "export LIBPATH; "
+              "%(cd_action)s%(mkdirs)s%(action)s" % {
+            'action': action,
+            'cd_action': cd_action,
+            'count': count,
+            'mkdirs': mkdirs,
+            'name': name,
+          })
+        else:
+          self.WriteLn(
+              "cmd_%(name)s_%(count)d = LD_LIBRARY_PATH="
               "$(builddir)/lib.host:$(builddir)/lib.target:$$LD_LIBRARY_PATH; "
               "export LD_LIBRARY_PATH; "
               "%(cd_action)s%(mkdirs)s%(action)s" % {
-          'action': action,
-          'cd_action': cd_action,
-          'count': count,
-          'mkdirs': mkdirs,
-          'name': name,
-        })
+            'action': action,
+            'cd_action': cd_action,
+            'count': count,
+            'mkdirs': mkdirs,
+            'name': name,
+          })
         self.WriteLn(
             'quiet_cmd_%(name)s_%(count)d = RULE %(name)s_%(count)d $@' % {
           'count': count,
@@ -1377,6 +1401,8 @@ $(obj).$(TOOLSET)/$(TARGET)/%%.o: $(obj)/%%%s FORCE_DO_CMD
       target_prefix = 'lib'
       if self.flavor == 'aix':
         target_ext = '.a'
+      elif self.flavor == 'zos':
+        target_ext = '.x'
       else:
         target_ext = '.so'
     elif self.type == 'none':
@@ -1447,6 +1473,14 @@ $(obj).$(TOOLSET)/$(TARGET)/%%.o: $(obj)/%%%s FORCE_DO_CMD
       # This hack makes it work:
       # link_deps.extend(spec.get('libraries', []))
     return (gyp.common.uniquer(deps), gyp.common.uniquer(link_deps))
+
+  def GetSharedObjectFromSidedeck(self, sidedeck):
+    """Return the shared object files based on sidedeck"""
+    return re.sub(r'\.x$', '.so', sidedeck);
+
+  def GetUnversionedSidedeckFromSidedeck(self, sidedeck):
+    """Return the shared object files based on sidedeck"""
+    return re.sub(r'\.\d+\.x$', '.x', sidedeck)
 
 
   def WriteDependencyOnExtraOutputs(self, target, extra_outputs):
@@ -1623,6 +1657,11 @@ $(obj).$(TOOLSET)/$(TARGET)/%%.o: $(obj)/%%%s FORCE_DO_CMD
             ' '.join(QuoteSpaces(dep) for dep in link_deps)))
       self.WriteDoCmd([self.output_binary], link_deps, 'solink', part_of_all,
                       postbuilds=postbuilds)
+      # z/OS has a .so target as well as a sidedeck .x target
+      if self.flavor == "zos":
+        self.WriteLn('%s: %s' % (
+              QuoteSpaces(self.GetSharedObjectFromSidedeck(self.output_binary)),
+              QuoteSpaces(self.output_binary)))
     elif self.type == 'loadable_module':
       for link_dep in link_deps:
         assert ' ' not in link_dep, (
@@ -1665,7 +1704,9 @@ $(obj).$(TOOLSET)/$(TARGET)/%%.o: $(obj)/%%%s FORCE_DO_CMD
       else:
         file_desc = 'executable'
       install_path = self._InstallableTargetInstallPath()
-      installable_deps = [self.output]
+      installable_deps = []
+      if (self.flavor != 'zos'):
+        installable_deps.append(self.outputr)
       if (self.flavor == 'mac' and not 'product_dir' in spec and
           self.toolset == 'target'):
         # On mac, products are created in install_path immediately.
@@ -1680,15 +1721,39 @@ $(obj).$(TOOLSET)/$(TARGET)/%%.o: $(obj)/%%%s FORCE_DO_CMD
         self.WriteDoCmd([install_path], [self.output], 'copy',
                         comment = 'Copy this to the %s output path.' %
                         file_desc, part_of_all=part_of_all)
-        installable_deps.append(install_path)
+        if self.flavor != "zos":
+          installable_deps.append(install_path)
+
+        if self.flavor == 'zos' and self.type == 'shared_library':
+          # lib.target/libnode.so has a dependency on $(obj).target/libnode.so
+          self.WriteDoCmd([self.GetSharedObjectFromSidedeck(install_path)], 
+                          [self.GetSharedObjectFromSidedeck(self.output)], 'copy',
+                          comment = 'Copy this to the %s output path.' %
+                          file_desc, part_of_all=part_of_all)
+          # Create a symlink of libnode.x to libnode.version.x
+          self.WriteDoCmd([self.GetUnversionedSidedeckFromSidedeck(install_path)], 
+                          [install_path], 'symlink',
+                          comment = 'Symlnk this to the %s output path.' %
+                          file_desc, part_of_all=part_of_all)
+          # Place libnode.version.so and libnode.x symlink in lib.target dir
+          installable_deps.append(self.GetSharedObjectFromSidedeck(install_path))
+          installable_deps.append(self.GetUnversionedSidedeckFromSidedeck(install_path))
+
       if self.output != self.alias and self.alias != self.target:
         self.WriteMakeRule([self.alias], installable_deps,
                            comment = 'Short alias for building this %s.' %
                            file_desc, phony = True)
       if part_of_all:
-        self.WriteMakeRule(['all'], [install_path],
-                           comment = 'Add %s to "all" target.' % file_desc,
-                           phony = True)
+        if self.flavor == 'zos' and self.type == 'shared_library':
+          # Make sure that .x symlink target is run
+          self.WriteMakeRule(['all'], [self.GetUnversionedSidedeckFromSidedeck(install_path),
+                              self.GetSharedObjectFromSidedeck(install_path)],
+                             comment = 'Add %s to "all" target.' % file_desc,
+                             phony = True)
+        else:
+          self.WriteMakeRule(['all'], [install_path],
+                             comment = 'Add %s to "all" target.' % file_desc,
+                             phony = True)
 
 
   def WriteList(self, value_list, variable=None, prefix='',
@@ -2084,7 +2149,7 @@ def GenerateOutput(target_list, target_dicts, data, params):
     header_params.update({
         'copy_archive_args': copy_archive_arguments,
         'makedep_args': makedep_arguments,
-        'link_commands': LINK_COMMANDS_OS390,
+        'link_commands': LINK_COMMANDS_ZOS,
         'CC.target':   GetEnvironFallback(('CC_target', 'CC'), 'njsc'),
         'CXX.target':  GetEnvironFallback(('CXX_target', 'CXX'), 'njsc++'),
         'CC.host':     GetEnvironFallback(('CC_host', 'CC'), 'njsc'),

--- a/tools/install.py
+++ b/tools/install.py
@@ -117,11 +117,11 @@ def npm_files(action):
   if sys.platform == 'zos':
     link_path = abspath(install_path, 'bin/node-gyp')
     if action == uninstall:
-        action([link_path], 'bin/node-gyp')
+      action([link_path], 'bin/node-gyp')
     elif action == install:
-        try_symlink('../lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js', link_path)
+      try_symlink('../lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js', link_path)
     else:
-        assert 0 # unhandled action type
+      assert 0 # unhandled action type
 
 def subdir_files(path, dest, action):
   ret = {}

--- a/tools/install.py
+++ b/tools/install.py
@@ -7,6 +7,7 @@ import errno
 import os
 import shutil
 import sys
+import utils
 
 # set at init time
 node_prefix = '/usr/local' # PREFIX variable from Makefile
@@ -111,6 +112,17 @@ def npm_files(action):
   else:
     assert 0 # unhandled action type
 
+  # On z/OS, we install node-gyp for convenience as native add-ons
+  # are dependend on
+  if sys.platform == 'zos':
+    link_path = abspath(install_path, 'bin/node-gyp')
+    if action == uninstall:
+        action([link_path], 'bin/node-gyp')
+    elif action == install:
+        try_symlink('../lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js', link_path)
+    else:
+        assert 0 # unhandled action type
+
 def subdir_files(path, dest, action):
   ret = {}
   for dirpath, dirnames, filenames in os.walk(path):
@@ -140,7 +152,23 @@ def files(action):
   if 'false' == variables.get('node_shared'):
     action([output_prefix + output_file], 'bin/' + output_file)
   else:
-    action([output_prefix + output_file], 'lib/' + output_file)
+    if sys.platform == 'zos':
+      # Install libnode.version.x
+      action([output_prefix + output_file], 'lib/' + output_file)
+
+      # Create libnode.x that references libnode.so (for native node module compat)
+      so_name = 'libnode.' + re.sub(r'\.x$', '.so', variables.get('shlib_suffix'))
+      os.system("sed -e 's/" + so_name + "/libnode.so/g'" + " " + 
+        abspath(install_path, 'lib/' + output_file)  + " > " + abspath(install_path, 'lib/libnode.x'))
+
+      # Install libnode.version.so
+      action([output_prefix + so_name], 'lib/' + so_name)
+
+      # Create symlink of libnode.so -> libnode.version.so (for native node module compat)
+      link_path = abspath(install_path, 'lib/libnode.so')
+      try_symlink(so_name, link_path)
+    else:
+      action([output_prefix + output_file], 'lib/' + output_file)
 
   if 'true' == variables.get('node_use_dtrace'):
     action(['out/Release/node.d'], 'lib/dtrace/node.d')
@@ -157,6 +185,10 @@ def files(action):
     action(['doc/node.1'], 'share/man/man1/')
 
   if 'true' == variables.get('node_install_npm'): npm_files(action)
+
+  # z/OS does not have an ICU offering, ship built dat files
+  if sys.platform == 'zos':
+    action([output_prefix + 'obj/gen/icutmp/icusmdt64.dat'], 'lib/')
 
   headers(action)
 


### PR DESCRIPTION
* This PR enables node versioned shared libraries for z/OS
* The shared libraries will now be stores in lib.target as opposed to obj.target
   libnode.version.so, libnode.x (for npm backwards compat and testing), and libnode.version.x (for builds)
* The install will also include:
   * libnode.so link that points to libnode.version.so (this will be used by native npms for backwards compat)
   

I also modified `src/node_main.cc` to initialize zoslib and libpath.  (**This should be a seperate PR for master)**