### PR TITLE
build: use zoslib_include_dir provided by node-gyp

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -619,7 +619,7 @@
           '-q64',
         ],
         # for addons due to v8config.h include of "zos-base.h":
-        'include_dirs':  ['$(ZOSLIB_INCLUDES)'],
+        'include_dirs':  ['<(zoslib_include_dir)'],
       }],
     ],
   }

--- a/configure.py
+++ b/configure.py
@@ -1160,7 +1160,8 @@ def configure_zos(o):
   o['variables']['node_static_zoslib'] = b(True)
   if options.static_zoslib_gyp:
     # Apply to all Node.js components for now
-    o['include_dirs'] += [os.path.dirname(options.static_zoslib_gyp) + '/include']
+    o['variables']['zoslib_include_dir'] = os.path.dirname(options.static_zoslib_gyp) + '/include'
+    o['include_dirs'] += [o['variables']['zoslib_include_dir']]
   else:
     raise Exception('--static-zoslib-gyp=<path to zoslib.gyp file> is required.')
 


### PR DESCRIPTION
Use `zoslib_include_dir` variable to get zoslib header files, which allow node.js to dynamically search for it instead of completely rely on user input.

Depends on https://github.com/ibmruntimes/node-zos/pull/13 and https://github.com/ibmruntimes/node-gyp/pull/1

Used to be part of https://github.com/ibmruntimes/node-zos/pull/13, but since it require https://github.com/ibmruntimes/node-gyp/pull/1, I separate it into 2 PR.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
