### PR TITLE
lib: add envar to force IPV4 dns resolution

### DIFF
--- a/lib/dns.js
+++ b/lib/dns.js
@@ -142,6 +142,12 @@ function lookup(hostname, options, callback) {
 
   validateOneOf(family, 'family', [0, 4, 6]);
 
+  if (process.platform === 'os390' &&
+      process.env.NODE_DNSIPV4 &&
+      (family === 0 || family === 6)) {
+    family = 4;
+  }
+
   if (!hostname) {
     emitInvalidHostnameWarning(hostname);
     if (all) {

--- a/lib/internal/main/print_help.js
+++ b/lib/internal/main/print_help.js
@@ -18,6 +18,7 @@ const {
 
 const { types } = internalBinding('options');
 const hasCrypto = Boolean(process.versions.openssl);
+const isZOS = process.platform === 'os390';
 
 const {
   prepareMainThreadExecution
@@ -64,16 +65,18 @@ const envVars = new SafeMap(ArrayPrototypeConcat([
 ], hasIntl ? [
   ['NODE_ICU_DATA', { helpText: 'data path for ICU (Intl object) data' +
     hasSmallICU ? '' : ' (will extend linked-in data)' }],
-] : []), (hasNodeOptions ? [
+] : [], hasNodeOptions ? [
   ['NODE_OPTIONS', { helpText: 'set CLI options in the environment via a ' +
     'space-separated list' }],
-] : []), hasCrypto ? [
+] : [], hasCrypto ? [
   ['OPENSSL_CONF', { helpText: 'load OpenSSL configuration from file' }],
   ['SSL_CERT_DIR', { helpText: 'sets OpenSSL\'s directory of trusted ' +
     'certificates when used in conjunction with --use-openssl-ca' }],
   ['SSL_CERT_FILE', { helpText: 'sets OpenSSL\'s trusted certificate file ' +
     'when used in conjunction with --use-openssl-ca' }],
-] : []);
+] : [], isZOS ? [
+  ['NODE_DNSIPV4', { helpText: 'set to 1 to force ipv4 DNS resolution' }],
+] : []));
 
 
 function indent(text, depth) {

--- a/lib/net.js
+++ b/lib/net.js
@@ -1044,6 +1044,12 @@ function lookupAndConnect(self, options) {
     dnsopts.hints = dns.ADDRCONFIG;
   }
 
+  if (process.platform === 'os390' &&
+      process.env.NODE_DNSIPV4 &&
+      (dnsopts.family === 0 || dnsopts.family === 6)) {
+    dnsopts.family = 4;
+  }
+
   debug('connect: find host', host);
   debug('connect: dns options', dnsopts);
   self._host = host;


### PR DESCRIPTION
Allow some z/OS system to force IPv4 DNS resolution as some system maybe not support IPv6. Also fix the typo which excluded the help menu after the ICU options. (Verified it happen on linux as well)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
