### PR TITLE
lib: pass env variables to child process on z/OS

### DIFF
--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -91,6 +91,8 @@ const {
 
 const MAX_BUFFER = 1024 * 1024;
 
+const isZOS = process.platform === 'os390';
+
 /**
  * Spawns a new Node.js process + fork.
  * @param {string|URL} modulePath
@@ -490,6 +492,14 @@ ObjectDefineProperty(execFile, promisify.custom, {
   value: customPromiseExecFunction(execFile)
 });
 
+function copyProcessEnvToEnv(env, name, optionEnv) {
+  optionEnv = optionEnv || {};
+  if (process.env[name] &&
+      !ObjectPrototypeHasOwnProperty(optionEnv, name)) {
+    env[name] = process.env[name];
+  }
+}
+
 function normalizeSpawnArguments(file, args, options) {
   validateString(file, 'file');
 
@@ -596,9 +606,20 @@ function normalizeSpawnArguments(file, args, options) {
 
   // process.env.NODE_V8_COVERAGE always propagates, making it possible to
   // collect coverage for programs that spawn with white-listed environment.
-  if (process.env.NODE_V8_COVERAGE &&
-      !ObjectPrototypeHasOwnProperty(options.env || {}, 'NODE_V8_COVERAGE')) {
-    env.NODE_V8_COVERAGE = process.env.NODE_V8_COVERAGE;
+  copyProcessEnvToEnv(env, 'NODE_V8_COVERAGE', options.env);
+
+  if (isZOS) {
+    // The following environment variables must always propagate if set
+    copyProcessEnvToEnv(env, '_BPXK_AUTOCVT', options.env);
+    copyProcessEnvToEnv(env, '_CEE_RUNOPTS', options.env);
+    copyProcessEnvToEnv(env, '_TAG_REDIR_ERR', options.env);
+    copyProcessEnvToEnv(env, '_TAG_REDIR_IN', options.env);
+    copyProcessEnvToEnv(env, '_TAG_REDIR_OUT', options.env);
+    copyProcessEnvToEnv(env, 'STEPLIB', options.env);
+    copyProcessEnvToEnv(env, 'LIBPATH', options.env);
+    copyProcessEnvToEnv(env, '__MEM_ACCOUNT', options.env);
+    copyProcessEnvToEnv(env, '_EDC_SIG_DFLT', options.env);
+    copyProcessEnvToEnv(env, '_EDC_SUSV3', options.env);
   }
 
   let envKeys = [];


### PR DESCRIPTION
Pass required environment variables when spawning new child process. Also refactor it into a helper function

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
