### PR TITLE
src: initialize libpath on z/OS

### DIFF
--- a/src/node_main.cc
+++ b/src/node_main.cc
@@ -96,6 +96,14 @@ int wmain(int argc, wchar_t* wargv[]) {
 #include <signal.h>
 #endif
 
+#if defined(__MVS__)
+#include "zos-setlibpath.h"
+
+// z/OS linker doesn't support rpath function, so we set LIBPATH in the source
+// so libnode DLL can load.
+__setlibpath libpath;
+#endif
+
 namespace node {
 namespace per_process {
 extern bool linux_at_secure;


### PR DESCRIPTION
z/OS linker doesn't support rpath function, so we initialize libpath in the source

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
